### PR TITLE
Scale and margins for paper plot

### DIFF
--- a/src/include/paperplot/PaperPlot.jl
+++ b/src/include/paperplot/PaperPlot.jl
@@ -58,6 +58,7 @@ function paperplot(
 
     # Margins
     plot!.(plots[[1, 4]], left_margin=10Plots.mm)
+    plot!.(plots[[2,3,5,6]], left_margin=-4Plots.mm)
     plot!.(plots[[3, 6]], right_margin=5Plots.mm)
     plot!.(plots[1:3], bottom_margin=-3Plots.mm)
     plot!.(plots[4:6], bottom_margin=5Plots.mm)

--- a/src/include/paperplot/PaperPlot.jl
+++ b/src/include/paperplot/PaperPlot.jl
@@ -78,6 +78,7 @@ function paperplot(
                          framestyle = :box,
                          fontfamily = "serif-roman",
                          size = (1200, 500),
+                         thickness_scaling = 1.3,
                          ;
                          logscale_kw...,
                          plotargs...


### PR DESCRIPTION
- paperplot: scale fonts to match latex caption
- paperplot: stretch horizontal margins
