### PR TITLE
Use dictionary to specify number of resamplings per iteration

### DIFF
--- a/docs/src/optimizers.md
+++ b/docs/src/optimizers.md
@@ -31,7 +31,7 @@ Optimizers of this category accept the arguments:
 - `blocking`: Allows to accept only variable updates which improve the value of the function up to certain tolerance. Default value is `false`.
 - `blocking_tol`: The tolerance used for blocking. Default value is `0.0`.
 - `blocking_Ncalibrate`: Is an integer representing how many evaluations of the function on the seed value should be used to estimate its standard deviation. If `blocking_Ncalibrate > 1`, then `blocking_tol` is overriden with the value of twice the standard deviation. The default value of `blocking_Ncalibrate` is `0`.
-- `Nresampling`: Integer indicating how many times to estimate the gradient to use an average at each iteration. Default value is `1`.
+- `resamplings`: Dictionary containing the number of samples of the gradient estimator to average at each iteration. It must contain the key `"default"` with the value which will be used for iterations without explicit specification. By default, `resamplings = Dict("default" => 1)`.
 - `postprocess`: A function which takes the array of variables `z` at the end of each iteration, and returns a postprocessed version of it. The default value is `identity`, which returns its arguments identically.
 
 ### Optimizers
@@ -54,9 +54,10 @@ CSPSA
 
 ### Options
 
-All of the options for first-order optimizers may also be provided. Additionally, preconditioned optimizers take the following options:
+All of the options for first-order optimizers, excepting `learning_rate_Ncalibrate`, may also be provided. Additionally, preconditioned optimizers take the following options:
 
 - `initial_hessian`: Allows to pass a guess for the initial value of the Hessian estimator. If not given, an Identity matrix is used.
+- `resamplings`: Dictionary containing the number of samples of the gradient estimator to average at each iteration. It must contain the key `"default"` with the value which will be used for iterations without explicit specification. If `resamplings[0]` is defined, it will be used to compute an estimator as the initial Hessian, overwriting the value possibly provided with `initial_hessian.` By default, `resamplings = Dict("default" => 1)`.
 - `hessian_delay`: An integer indicating how many iterations should be performed using a first-order optimization rule (while collecting information for the Hessian estimator) before using the Hessian estimator to precondition the gradient estimator. The default value is `0`.
 - `a2`: Mimics the first-order gain parameter `a` but for preconditioned iterations. Default value is `1.0`. As in the first-order case, the keyword `learning_rate_constant` may be used to control wether the learning rate should be constant or decaying on the iteration number.
 - `regularization`: A real number indicating the perturbation used on the Hessian regularization. The default value is `0.001`.

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -76,7 +76,6 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
                          blocking = false,
                          blocking_tol = 0.0,
                          blocking_Ncalibrate = 0,
-                         learning_rate_Ncalibrate = 0,
                          learning_rate_constant = false,
                          resamplings = Dict("default" => 1),
                          postprocess = identity,
@@ -102,10 +101,10 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
     end
 
     # Obtain an initial Hessian estimate by measurement
-    if learning_rate_Ncalibrate > 0
+    if haskey(resamplings, 0)
+        Ncalibrate = resamplings[0]
         bk = decaying_pert_magnitude(b, t, initial_iter)
-        g, H0 = estimate_gH(f, fidelity, z, bk, bk,
-                            learning_rate_Ncalibrate, hessian_estimate)
+        g, H0 = estimate_gH(f, fidelity, z, bk, bk, Ncalibrate, hessian_estimate)
     end
 
     # Blocking

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -78,7 +78,7 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
                          blocking_Ncalibrate = 0,
                          learning_rate_Ncalibrate = 0,
                          learning_rate_constant = false,
-                         Nresampling = 1,
+                         resamplings = Dict("default" => 1),
                          postprocess = identity,
                          hessian_delay = 0,
                          initial_hessian = nothing,
@@ -121,8 +121,8 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
         bk = decaying_pert_magnitude(b, t, k)
 
         # Estimates of the gradient and Hessian
-        g, H = estimate_gH(f, fidelity, z, bk, bk,
-                           Nresampling, hessian_estimate)
+        Nresampling = haskey(resamplings, iter) ? resamplings[iter] : resamplings["default"]
+        g, H = estimate_gH(f, fidelity, z, bk, bk, Nresampling, hessian_estimate)
 
         # Second order usually requires fixing the Hessian
         H0 = hessian_postprocess(H, H0, iter,

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -8,7 +8,7 @@ function _first_order(f::Function, guess::AbstractVector, Niters;
                       blocking = false,
                       blocking_tol = 0.0,
                       blocking_Ncalibrate = 0,
-                      Nresampling = 1,
+                      resamplings = Dict("default" => 1),
                       postprocess = identity,
                       )
 
@@ -39,6 +39,7 @@ function _first_order(f::Function, guess::AbstractVector, Niters;
         bk = decaying_pert_magnitude(b, t, k)
 
         # Estimates of the gradient and Hessian
+        Nresampling = haskey(resamplings, iter) ? resamplings[iter] : resamplings["default"]
         g = estimate_g(f, z, bk, Nresampling)
 
         # Updated variable


### PR DESCRIPTION
- deprecate Nresampling in favor of resamplings::Dict (for first order)
- deprecate Nresapmpling in favor of resamplings::Dict (preconditioned)
- deprecate learning_rate_Ncalibrate in favor of resamplings[0]
- update docs
