### PR TITLE
fix update when blocking is false

### DIFF
--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -151,6 +151,8 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
                 # Make update
                 z = z_next
             end
+        else
+            z = z_next
         end
 
         # Apply posibble inter-iteration postprocessing

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -54,6 +54,8 @@ function _first_order(f::Function, guess::AbstractVector, Niters;
                 # Make update
                 z = z_next
             end
+        else
+            z = z_next
         end
 
         # postprocessing


### PR DESCRIPTION
The variable update was never being performed when `blocking` was `false`. This PR fixes that issue. 

- fix update for first_order
- fix update for second_order
