### PR TITLE
Fix blocking

### DIFF
--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -47,10 +47,10 @@ function _first_order(f::Function, guess::AbstractVector, Niters;
 
         # Blocking
         if blocking
-            fz_new = f(z)
-            if fz_new * sign > fz_prev * sign - blocking_tol
+            fz_next = f(z)
+            if fz_next*sign > fz_prev*sign - blocking_tol
                 # Accept new value of f(z)
-                fz_prev = fz_new
+                fz_prev = fz_next
                 # Make update
                 z = z_next
             end

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -144,10 +144,10 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
 
         # Blocking
         if blocking
-            fz_new = f(z)
-            if fz_new * sign > fz_prev * sign - blocking_tol
+            fz_next = f(z)
+            if fz_next*sign > fz_prev*sign - blocking_tol
                 # Accept new value of f(z)
-                fz_prev = fz_new
+                fz_prev = fz_next
                 # Make update
                 z = z_next
             end

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -144,7 +144,7 @@ function _preconditioned(f::Function, guess::AbstractVector, Niters;
 
         # Blocking
         if blocking
-            fz_next = f(z)
+            fz_next = f(z_next)
             if fz_next*sign > fz_prev*sign - blocking_tol
                 # Accept new value of f(z)
                 fz_prev = fz_next

--- a/src/include/core_optimizers.jl
+++ b/src/include/core_optimizers.jl
@@ -47,7 +47,7 @@ function _first_order(f::Function, guess::AbstractVector, Niters;
 
         # Blocking
         if blocking
-            fz_next = f(z)
+            fz_next = f(z_next)
             if fz_next*sign > fz_prev*sign - blocking_tol
                 # Accept new value of f(z)
                 fz_prev = fz_next

--- a/src/include/estimates.jl
+++ b/src/include/estimates.jl
@@ -103,4 +103,4 @@ function estimate_gH(f::Function, fidelity::Function, z,
 end
 
 # Estimate standard deviation
-estimate_std(f, z, N) = std([f(z) for _ in 1:N])
+estimate_std(f, z, N) = std(f(z) for _ in 1:N)


### PR DESCRIPTION
- estimate_std with generator instead of explicit vector
- make variable names coherent (preconditioned)
- fix fz_next (preconditioned)
- make names coherent (first order)
- fix fz_next (first order)
